### PR TITLE
Deploy to Google App Engine with Commit SHA

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,6 +49,7 @@ steps:
     - deploy
     - ./dist/app.yaml
     - --project=${_TARGET_PROJECT_}
+    - --version=$SHORT_SHA
   waitFor:
     - build
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
This will replace the default date time version, which does
not aid quick debugging or identifying what is running
on which environment.

Closes #14